### PR TITLE
Add support for including CLI variables in plugin add command.

### DIFF
--- a/cli/android-cli.js
+++ b/cli/android-cli.js
@@ -50,13 +50,27 @@ function writeIfNotExists(filename, data) {
     }
 }
 
-Android.prototype.add = function (plugin) {
+// takes an array or variables and turns them into an object to be consumed by plugman
+function mapVariablesToObject(variables) {
+  var plugmanConsumableVariables = {};
+  for (var i in variables) {
+    var t = variables[i].split('=');
+    if (t[0] && t[1]) {
+      plugmanConsumableVariables[t[0]] = t[1];
+    }
+  }
+  return plugmanConsumableVariables;
+}
+
+Android.prototype.add = function (plugin, variables) {
     this.init();
     var self = this;
+    var plugmanConsumableVariables = mapVariablesToObject(variables);
     return cordova.plugman.raw.install('android', PLATFORM_DIR, plugin, path.resolve(this.projectRoot, 'node_modules'), {
         platformVersion: '5.0.0',
         //TODO - figure out a way to make cordova browserify only to selectively pick files
-        browserify: false
+        browserify: false,
+        cli_variables: plugmanConsumableVariables
     }).then(function () {
         return generateCordovaJs(self.projectRoot);
     }).then(function () {

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -4,7 +4,7 @@ var argv = require('minimist')(process.argv.slice(2));
 var path = require('path');
 var Q = require('q');
 
-// TODO Check if this is a react-native project. 
+// TODO Check if this is a react-native project.
 var projectDir = '.';
 
 var Android = require('./android-cli');
@@ -12,11 +12,11 @@ var Android = require('./android-cli');
 var android = new Android(projectDir);
 
 var commands = {
-    add: function(plugins) {
+    add: function(plugins, variables) {
         console.log('Adding plugins %s', plugins.join());
         return plugins.map(function(pluginName) {
             return function() {
-                return android.add(pluginName);
+                return android.add(pluginName, variables);
             }
         }).reduce(Q.when, Q());
     },
@@ -54,8 +54,14 @@ switch (argv._[0]) {
         command = argv._[0];
 }
 
+var passedInVariables = argv['variable'];
+if (typeof passedInVariables === 'string') {
+  // set single variables to be an array
+  passedInVariables = [passedInVariables];
+}
+
 if (typeof commands[command] === 'function') {
-    commands[command](plugins).then(function() {
+    commands[command](plugins, passedInVariables).then(function() {
         console.log('Done with [%s] %s', command, plugins);
     }, function(err) {
         console.log('An error occured ===> \n', err);


### PR DESCRIPTION
CLI variables are necessary to install some plugins, like:
- https://github.com/mapsplugin/cordova-plugin-googlemaps
- https://github.com/j3k0/cordova-plugin-purchase

This commit adds support for CLI commands by simply passing them to Plugman to handle. I have tested these changes and they work for me.

Theoretically this should not break the ability to add multiple plugins per add command - you can even specify multiple variables and have them passed to each plugin safely, as long as there is not overlap in the variable names for each plugin (e.g. two plugins that require APIKEY added in the same command).

You can find support for CLI variables in the plugin spec:
https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html
